### PR TITLE
Handle empty review list in ExperienceDetail

### DIFF
--- a/components/ExperienceDetail.tsx
+++ b/components/ExperienceDetail.tsx
@@ -32,7 +32,9 @@ const renderStars = (rating: number) => {
 };
 
 const ExperienceDetail: React.FC<ExperienceDetailProps> = ({ experience, onBack }) => {
-  const averageRating = mockReviews.reduce((acc, review) => acc + review.rating, 0) / mockReviews.length;
+  const averageRating = mockReviews.length
+    ? mockReviews.reduce((acc, review) => acc + review.rating, 0) / mockReviews.length
+    : 0;
 
   return (
     <div className="animate-slide-in-right">


### PR DESCRIPTION
## Summary
- prevent divide-by-zero when computing average review rating in ExperienceDetail

## Testing
- `npm run build` *(fails: Unable to parse HTML; parse5 error code eof-in-element-that-can-contain-only-text at /workspace/vexel/index.html:402:1)*

------
https://chatgpt.com/codex/tasks/task_e_68b35478e1788328aef2284f500e154a